### PR TITLE
Async WASI imports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,20 +14,18 @@ doc = false
 
 [features]
 default = ["run", "compile", "pack", "hub", "llvm"]
-full = ["run", "compile", "pack", "hub", "appended_artifacts", "llvm"]
+full = ["run", "compile", "pack", "hub", "llvm", "appended_artifacts"]
 
 run = ["webrogue-cli/run"]
 compile = ["webrogue-cli/compile"]
 pack = ["webrogue-cli/pack"]
 hub = ["webrogue-cli/hub"]
+llvm = ["webrogue-cli/llvm"]
 
 # to use this feature, you need to process resulting binary 
 # using append_artifacts.py script, so it is disabled by default
 appended_artifacts = ["webrogue-cli/appended_artifacts"]
 
-# llvm feature is disabled by default so rust-analyzer don't
-# have to wait while LLVM compiles
-llvm = ["webrogue-cli/llvm"]
 
 [dependencies]
 webrogue-cli = { workspace = true }

--- a/crates/debugger/src/code_runner_loop.rs
+++ b/crates/debugger/src/code_runner_loop.rs
@@ -19,6 +19,7 @@ pub fn runner<T: Send + 'static>(
     let is_main_thread_arc = Arc::new(AtomicBool::new(true));
     Arc::new(move |params, func| {
         tokio::runtime::Builder::new_current_thread()
+            .enable_all()
             .build()
             .unwrap()
             .block_on((async || {

--- a/crates/debugger/src/connection.rs
+++ b/crates/debugger/src/connection.rs
@@ -42,10 +42,10 @@ impl Connection {
 
     pub fn flush(&mut self) -> anyhow::Result<()> {
         if self.needs_flush {
-            eprintln!("");
-            eprintln!("-> to client");
-            eprintln!("{}", String::from_utf8_lossy(&self.buffer));
-            eprintln!("<- from client");
+            // eprintln!("");
+            // eprintln!("-> to client");
+            // eprintln!("{}", String::from_utf8_lossy(&self.buffer));
+            // eprintln!("<- from client");
 
             tokio::runtime::Handle::current()
                 .block_on(async { self.sender.send(&self.buffer).await })?;

--- a/crates/debugger/src/gdb_stub_loop.rs
+++ b/crates/debugger/src/gdb_stub_loop.rs
@@ -1,4 +1,4 @@
-use std::io::Write as _;
+// use std::io::Write as _;
 
 use gdbstub::stub::MultiThreadStopReason;
 use tokio::io::AsyncReadExt as _;
@@ -78,8 +78,8 @@ pub fn run(
 
 async fn receive_byte(receiver: &mut BoxedPacketReceiver) -> anyhow::Result<u8> {
     let byte = receiver.read_u8().await?;
-    eprint!("{}", byte as char);
-    std::io::stderr().flush().unwrap();
+    // eprint!("{}", byte as char);
+    // std::io::stderr().flush().unwrap();
     Ok(byte)
 }
 

--- a/crates/wasmtime/src/runtime.rs
+++ b/crates/wasmtime/src/runtime.rs
@@ -280,6 +280,18 @@ fn run_module<Builder: webrogue_gfx::IBuilder, VFSHandle: webrogue_wrapp::IVFSHa
         #[cfg(feature = "async")]
         async_func_runner.clone(),
     )));
+
+    #[cfg(feature = "async")]
+    if async_func_runner.is_some() {
+        bindings::not_sync::add_wasi_snapshot_preview1_to_linker(&mut linker, |state| {
+            state.preview1_ctx.as_mut().unwrap()
+        })?;
+    } else {
+        bindings::sync::add_wasi_snapshot_preview1_to_linker(&mut linker, |state| {
+            state.preview1_ctx.as_mut().unwrap()
+        })?;
+    }
+    #[cfg(not(feature = "async"))]
     bindings::add_wasi_snapshot_preview1_to_linker(&mut linker, |state| {
         state.preview1_ctx.as_mut().unwrap()
     })?;
@@ -334,9 +346,6 @@ fn run_module<Builder: webrogue_gfx::IBuilder, VFSHandle: webrogue_wrapp::IVFSHa
 
                 let pre = linker.instantiate_pre(&module)?;
 
-                let instance = pre.instantiate(&mut store)?;
-                let func = instance.get_typed_func::<(), ()>(&mut store, "_start")?;
-
                 #[cfg(feature = "async")]
                 let call_result = if let Some(async_func_runner) = async_func_runner {
                     async_func_runner(
@@ -348,6 +357,10 @@ fn run_module<Builder: webrogue_gfx::IBuilder, VFSHandle: webrogue_wrapp::IVFSHa
                             use wasmtime::AsContextMut as _;
 
                             Box::pin(async move {
+                                let instance =
+                                    pre.instantiate_async(store.as_context_mut()).await?;
+                                let func = instance
+                                    .get_typed_func::<(), ()>(store.as_context_mut(), "_start")?;
                                 store
                                     .edit_breakpoints()
                                     .as_mut()
@@ -360,13 +373,18 @@ fn run_module<Builder: webrogue_gfx::IBuilder, VFSHandle: webrogue_wrapp::IVFSHa
                     )
                     .map(|_| ())
                 } else {
+                    let instance = pre.instantiate(&mut store)?;
+                    let func = instance.get_typed_func::<(), ()>(&mut store, "_start")?;
                     func.call(&mut store, ())
                         .map_err(|err| anyhow::anyhow!(err))
                 };
                 #[cfg(not(feature = "async"))]
-                let call_result = func
-                    .call(&mut store, ())
-                    .map_err(|err| anyhow::anyhow!(err));
+                let call_result = {
+                    let instance = pre.instantiate(&mut store)?;
+                    let func = instance.get_typed_func::<(), ()>(&mut store, "_start")?;
+                    func.call(&mut store, ())
+                        .map_err(|err| anyhow::anyhow!(err))
+                };
                 let tid = main_thread.tid();
                 thread_registry.remove_thread(main_thread);
                 thread_registry.stop_all_threads(
@@ -395,9 +413,20 @@ mod bindings {
         witx: ["../gfx/witx/webrogue_gfx.witx"],
     });
 
-    wiggle::wasmtime_integration!({
-        target: webrogue_wasi_common::snapshots::preview_1,
-        witx: ["../../external/wasmtime/crates/wasi-common/witx/preview1/wasi_snapshot_preview1.witx"],
-        block_on [webrogue_wasip1::run_in_executor]: *
-    });
+    pub mod sync {
+        wiggle::wasmtime_integration!({
+            target: webrogue_wasi_common::snapshots::preview_1,
+            witx: ["../../external/wasmtime/crates/wasi-common/witx/preview1/wasi_snapshot_preview1.witx"],
+            block_on [webrogue_wasip1::run_in_executor]: *
+        });
+    }
+    #[cfg(feature = "async")]
+    // Not gonna fight compiler again
+    pub mod not_sync {
+        wiggle::wasmtime_integration!({
+            target: webrogue_wasi_common::snapshots::preview_1,
+            witx: ["../../external/wasmtime/crates/wasi-common/witx/preview1/wasi_snapshot_preview1.witx"],
+            async: *
+        });
+    }
 }

--- a/crates/wasmtime/src/runtime.rs
+++ b/crates/wasmtime/src/runtime.rs
@@ -292,7 +292,7 @@ fn run_module<Builder: webrogue_gfx::IBuilder, VFSHandle: webrogue_wrapp::IVFSHa
         })?;
     }
     #[cfg(not(feature = "async"))]
-    bindings::add_wasi_snapshot_preview1_to_linker(&mut linker, |state| {
+    bindings::sync::add_wasi_snapshot_preview1_to_linker(&mut linker, |state| {
         state.preview1_ctx.as_mut().unwrap()
     })?;
 


### PR DESCRIPTION
There were an issue: debugger and wasi used different tokio runtimes. This commit fixes this issue by marking imports as async