### PR TITLE
Attempt to speedup CI

### DIFF
--- a/.github/workflows/build_cli.yml
+++ b/.github/workflows/build_cli.yml
@@ -87,7 +87,7 @@ jobs:
         path: aot_artifacts
 
   android_artifacts:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
     - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,19 +16,15 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-24.04
-          components: cli,aot-lib
         - os: ubuntu-24.04-arm
           components: cli,aot-lib
         - os: windows-11-arm
-          components: cli,aot-lib
-        - os: windows-2025-vs2026
           components: cli,aot-lib
         - os: macos-26
           components: cli,aot-lib
         - os: macos-26
           components: ios,macos
-        - os: ubuntu-24.04
+        - os: ubuntu-24.04-arm
           components: android
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,23 +63,13 @@ jobs:
         rustup target add aarch64-apple-ios-sim
         rustup target add x86_64-apple-ios
 
-
-    - name: Setup Android NDK
-      if: contains(matrix.components, 'android') == true
-      uses: nttld/setup-ndk@v1
-      id: setup-ndk
-      with:
-        ndk-version: r29
-
-    - name: Run test scripts (UNIX)
+    - name: Run test scripts (on UNIX)
       if: startsWith(matrix.os, 'windows') == false
-      env:
-        ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
       run: |
         COMPONENTS=${{ matrix.components }} python3 scripts/cargo_check.py
         cargo test --package webrogue-wasip1
 
-    - name: Run test scripts (Windows)
+    - name: Run test scripts (on Windows)
       if: startsWith(matrix.os, 'windows') == true
       shell: cmd
       run: |
@@ -88,8 +78,8 @@ jobs:
         )
         REM gfxstream doesn't seem to support MSVC
         set CXX=clang-cl
-        COMPONENTS=${{ matrix.components }} python3 scripts\cargo_check.py
-        cargo test --package webrogue-wasip1
+        COMPONENTS=${{ matrix.components }} python3 scripts\cargo_check.py || exit /b 1
+        cargo test --package webrogue-wasip1 || exit /b 1
 
   typos:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,16 @@ jobs:
         include:
         - os: ubuntu-24.04
           components: cli,aot-lib
-        - os: windows-2025
+        - os: ubuntu-24.04-arm
+          components: cli,aot-lib
+        - os: windows-11-arm
+          components: cli,aot-lib
+        - os: windows-2025-vs2026
           components: cli,aot-lib
         - os: macos-26
-          components: cli,aot-lib,ios,macos
+          components: cli,aot-lib
+        - os: macos-26
+          components: ios,macos
         - os: ubuntu-24.04
           components: android
 


### PR DESCRIPTION
Some hacks to make CI finish a few minutes faster

Also replaces runner images with it's Arm variants where possible because Arm it's cool, cheap and has lower carbon footprint